### PR TITLE
fix esempi comandi in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ lua uninstallPackage("SPAM") installPackage("https://raw.githubusercontent.com/m
 ```
 Oppure scaricare ed importare in Mudlet l'[ultima release].
 
-Per i successivi aggiornamenti è possibile utilizzare in gioco il comando <spam update>
+Per i successivi aggiornamenti è possibile utilizzare in gioco il comando `spam update`
 
 ## Utilizzo
-Per esplorare tutte le funzioni del package basta digitare il comando <spam> in gioco
-Per le opzioni del monitor buff è possibile digitare il comando <observe>
+Per esplorare tutte le funzioni del package basta digitare il comando `spam` in gioco
+Per le opzioni del monitor buff è possibile digitare il comando `observe`
 
 
 [//]: # (These are reference links used in the body of this note and get stripped out when the markdown processor does its job. There is no need to format nicely because it shouldn't be seen. Thanks SO - http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax)


### PR DESCRIPTION
... che non vanno in tag HTML che senno' non vengono mostrati bene dal README. Vanno in backtick.